### PR TITLE
Replace deprecated dash-functional dependency

### DIFF
--- a/org-special-block-extras.el
+++ b/org-special-block-extras.el
@@ -4,7 +4,7 @@
 
 ;; Author: Musa Al-hassy <alhassy@gmail.com>
 ;; Version: 2.3
-;; Package-Requires: ((s "1.12.0") (dash "2.16.0") (emacs "26.1") (dash-functional "1.2.0") (org "9.1"))
+;; Package-Requires: ((s "1.12.0") (dash "2.18.0") (emacs "26.1") (org "9.1"))
 ;; Keywords: org, blocks, colors, convenience
 ;; URL: https://alhassy.github.io/org-special-block-extras
 
@@ -71,9 +71,6 @@
 (require 'dash)            ;; “A modern list library for Emacs”
 (require 'subr-x)          ;; Extra Lisp functions; e.g., ‘when-let’.
 (require 'cl-lib)          ;; New Common Lisp library; ‘cl-???’ forms.
-(require 'dash-functional) ;; Function library; ‘-const’, ‘-compose’, ‘-orfn’,
-                           ;; ‘-not’, ‘-partial’, etc.
-
 
 (require 'cus-edit) ;; To get the custom-* faces
 

--- a/org-special-block-extras.org
+++ b/org-special-block-extras.org
@@ -146,7 +146,7 @@ pre.src-C:before { content: 'Org-mode Example!'; }
 
 ;; Author: Musa Al-hassy <alhassy@gmail.com>
 ;; Version: 2.3
-;; Package-Requires: ((s "1.12.0") (dash "2.16.0") (emacs "26.1") (dash-functional "1.2.0") (org "9.1"))
+;; Package-Requires: ((s "1.12.0") (dash "2.18.0") (emacs "26.1") (org "9.1"))
 ;; Keywords: org, blocks, colors, convenience
 ;; URL: https://alhassy.github.io/org-special-block-extras
 
@@ -213,9 +213,6 @@ pre.src-C:before { content: 'Org-mode Example!'; }
 (require 'dash)            ;; “A modern list library for Emacs”
 (require 'subr-x)          ;; Extra Lisp functions; e.g., ‘when-let’.
 (require 'cl-lib)          ;; New Common Lisp library; ‘cl-???’ forms.
-(require 'dash-functional) ;; Function library; ‘-const’, ‘-compose’, ‘-orfn’,
-                           ;; ‘-not’, ‘-partial’, etc.
-
 
 (require 'cus-edit) ;; To get the custom-* faces
 


### PR DESCRIPTION
Dash 2.18.0 now subsumes `dash-functional`.

See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218