### PR TITLE
Exposed background-color as an option for the Details block.

### DIFF
--- a/org-special-block-extras.el
+++ b/org-special-block-extras.el
@@ -1003,31 +1003,35 @@ the following proves P = R.
                                (goto-char (point-min))
                                (org-list-to-lisp))))))
 
-(org-defblock details (title "Details") (title-color "green")
+(org-defblock details (title "Details")
+	      (background-color "#e5f5e5" title-color "green")
   "Enclose contents in a folded up box, for HTML.
 
 For LaTeX, this is just a boring, but centered, box.
 
-By default, the TITLE of such blocks is “Details”
-and its TITLE-COLOR is green.
+By default, the TITLE of such blocks is “Details”,
+its TITLE-COLOR is green, and BACKGROUND-COLOR is “#e5f5e5”.
 
 In HTML, we show folded, details, regions with a nice greenish colour.
 
 In the future ---i.e., when I have time---
-it may be prudent to expose more aspects as arguments,
-such as ‘background-color’.
+it may be prudent to expose more aspects as arguments.
 "
-  (format
    (pcase backend
-     (`latex "\\begin{quote}
-                  \\begin{tcolorbox}[colback=%s,title={%s},sharp corners,boxrule=0.4pt]
-                    %s
-                  \\end{tcolorbox}
-                \\end{quote}")
-     (_ "<details class=\"code-details\"
+     (`latex (concat (pcase (substring background-color 0 1)
+		       ("#" (format "\\definecolor{osbe-bg}{HTML}{%s}" (substring background-color 1)))
+		       (_ (format "\\colorlet{osbe-bg}{%s}" background-color)))
+		     (pcase (substring title-color 0 1)
+		       ("#" (format "\\definecolor{osbe-fg}{HTML}{%s}" (substring title-color 1)))
+		       (_ (format "\\colorlet{osbe-fg}{%s}" title-color)))
+		     (format "\\begin{quote}
+                              \\begin{tcolorbox}[colback=osbe-bg,colframe=osbe-fg,title={%s},sharp corners,boxrule=0.4pt]
+                                   %s
+                               \\end{tcolorbox}
+                \\end{quote}" title contents)))
+     (_ (format "<details class=\"code-details\"
                  style =\"padding: 1em;
-                          background-color: #e5f5e5;
-                          /* background-color: pink; */
+                          background-color: %s;
                           border-radius: 15px;
                           color: hsl(157 75% 20%);
                           font-size: 0.9em;
@@ -1040,34 +1044,37 @@ such as ‘background-color’.
                     </strong>
                   </summary>
                   %s
-               </details>"))
-   title-color title contents))
+               </details>" background-color title-color title contents))))
 
-(org-defblock Details (title "Details") (title-color "green")
+(org-defblock Details (title "Details")
+	      (background-color "#e5f5e5" title-color "green")
   "Enclose contents in a folded up box, for HTML.
 
 For LaTeX, this is just a boring, but centered, box.
 
 By default, the TITLE of such blocks is “Details”
-and its TITLE-COLOR is green.
+its TITLE-COLOR is green, and BACKGROUND-COLOR is “#e5f5e5”.
 
 In HTML, we show folded, details, regions with a nice greenish colour.
 
 In the future ---i.e., when I have time---
-it may be prudent to expose more aspects as arguments,
-such as ‘background-color’.
+it may be prudent to expose more aspects as arguments.
 "
-  (format
    (pcase backend
-     (`latex "\\begin{quote}
-                  \\begin{tcolorbox}[colback=%s,title={%s},sharp corners,boxrule=0.4pt]
-                    %s
-                  \\end{tcolorbox}
-                \\end{quote}")
-     (_ "<details class=\"code-details\"
+     (`latex (concat (pcase (substring background-color 0 1)
+		       ("#" (format "\\definecolor{osbe-bg}{HTML}{%s}" (substring background-color 1)))
+		       (_ (format "\\colorlet{osbe-bg}{%s}" background-color)))
+		     (pcase (substring title-color 0 1)
+		       ("#" (format "\\definecolor{osbe-fg}{HTML}{%s}" (substring title-color 1)))
+		       (_ (format "\\colorlet{osbe-fg}{%s}" title-color)))
+		     (format "\\begin{quote}
+                              \\begin{tcolorbox}[colback=osbe-bg,colframe=osbe-fg,title={%s},sharp corners,boxrule=0.4pt]
+                                   %s
+                               \\end{tcolorbox}
+                \\end{quote}" title contents)))
+     (_ (format "<details class=\"code-details\"
                  style =\"padding: 1em;
-                          background-color: #e5f5e5;
-                          /* background-color: pink; */
+                          background-color: %s;
                           border-radius: 15px;
                           color: hsl(157 75% 20%);
                           font-size: 0.9em;
@@ -1080,8 +1087,7 @@ such as ‘background-color’.
                     </strong>
                   </summary>
                   %s
-               </details>"))
-   title-color title contents))
+               </details>" background-color title-color title contents))))
 
 (org-defblock box (title "") (background-color nil shadow nil)
   "Enclose text in a box, possibly with a title.

--- a/org-special-block-extras.org
+++ b/org-special-block-extras.org
@@ -3123,31 +3123,35 @@ Requires: src_latex[:exports code]{,#+latex_header:  \usepackage{tcolorbox}}
 
 #+begin_details Implementation
 #+begin_src emacs-lisp
-(org-defblock details (title "Details") (title-color "green")
+(org-defblock details (title "Details")
+	      (background-color "#e5f5e5" title-color "green")
   "Enclose contents in a folded up box, for HTML.
 
 For LaTeX, this is just a boring, but centered, box.
 
-By default, the TITLE of such blocks is “Details”
-and its TITLE-COLOR is green.
+By default, the TITLE of such blocks is “Details”,
+its TITLE-COLOR is green, and BACKGROUND-COLOR is “#e5f5e5”.
 
 In HTML, we show folded, details, regions with a nice greenish colour.
 
 In the future ---i.e., when I have time---
-it may be prudent to expose more aspects as arguments,
-such as ‘background-color’.
+it may be prudent to expose more aspects as arguments.
 "
-  (format
    (pcase backend
-     (`latex "\\begin{quote}
-                  \\begin{tcolorbox}[colback=%s,title={%s},sharp corners,boxrule=0.4pt]
-                    %s
-                  \\end{tcolorbox}
-                \\end{quote}")
-     (_ "<details class=\"code-details\"
+     (`latex (concat (pcase (substring background-color 0 1)
+		       ("#" (format "\\definecolor{osbe-bg}{HTML}{%s}" (substring background-color 1)))
+		       (_ (format "\\colorlet{osbe-bg}{%s}" background-color)))
+		     (pcase (substring title-color 0 1)
+		       ("#" (format "\\definecolor{osbe-fg}{HTML}{%s}" (substring title-color 1)))
+		       (_ (format "\\colorlet{osbe-fg}{%s}" title-color)))
+		     (format "\\begin{quote}
+                              \\begin{tcolorbox}[colback=osbe-bg,colframe=osbe-fg,title={%s},sharp corners,boxrule=0.4pt]
+                                   %s
+                               \\end{tcolorbox}
+                \\end{quote}" title contents)))
+     (_ (format "<details class=\"code-details\"
                  style =\"padding: 1em;
-                          background-color: #e5f5e5;
-                          /* background-color: pink; */
+                          background-color: %s;
                           border-radius: 15px;
                           color: hsl(157 75% 20%);
                           font-size: 0.9em;
@@ -3160,8 +3164,7 @@ such as ‘background-color’.
                     </strong>
                   </summary>
                   %s
-               </details>"))
-   title-color title contents))
+               </details>" background-color title-color title contents))))
 #+end_src
 
 #+RESULTS:
@@ -3172,31 +3175,35 @@ Above is a lower-case ‘d’etails block, we now make a captial-case ‘D’eta
 block, for the not-too-odd situation we want to have, right away, one details block
 within another.
 #+begin_src emacs-lisp :exports none
-(org-defblock Details (title "Details") (title-color "green")
+(org-defblock Details (title "Details")
+	      (background-color "#e5f5e5" title-color "green")
   "Enclose contents in a folded up box, for HTML.
 
 For LaTeX, this is just a boring, but centered, box.
 
 By default, the TITLE of such blocks is “Details”
-and its TITLE-COLOR is green.
+its TITLE-COLOR is green, and BACKGROUND-COLOR is “#e5f5e5”.
 
 In HTML, we show folded, details, regions with a nice greenish colour.
 
 In the future ---i.e., when I have time---
-it may be prudent to expose more aspects as arguments,
-such as ‘background-color’.
+it may be prudent to expose more aspects as arguments.
 "
-  (format
    (pcase backend
-     (`latex "\\begin{quote}
-                  \\begin{tcolorbox}[colback=%s,title={%s},sharp corners,boxrule=0.4pt]
-                    %s
-                  \\end{tcolorbox}
-                \\end{quote}")
-     (_ "<details class=\"code-details\"
+     (`latex (concat (pcase (substring background-color 0 1)
+		       ("#" (format "\\definecolor{osbe-bg}{HTML}{%s}" (substring background-color 1)))
+		       (_ (format "\\colorlet{osbe-bg}{%s}" background-color)))
+		     (pcase (substring title-color 0 1)
+		       ("#" (format "\\definecolor{osbe-fg}{HTML}{%s}" (substring title-color 1)))
+		       (_ (format "\\colorlet{osbe-fg}{%s}" title-color)))
+		     (format "\\begin{quote}
+                              \\begin{tcolorbox}[colback=osbe-bg,colframe=osbe-fg,title={%s},sharp corners,boxrule=0.4pt]
+                                   %s
+                               \\end{tcolorbox}
+                \\end{quote}" title contents)))
+     (_ (format "<details class=\"code-details\"
                  style =\"padding: 1em;
-                          background-color: #e5f5e5;
-                          /* background-color: pink; */
+                          background-color: %s;
                           border-radius: 15px;
                           color: hsl(157 75% 20%);
                           font-size: 0.9em;
@@ -3209,8 +3216,7 @@ such as ‘background-color’.
                     </strong>
                   </summary>
                   %s
-               </details>"))
-   title-color title contents))
+               </details>" background-color title-color title contents))))
 #+end_src
 MA: TODO: The above should not be present, it should instead be factored out
 into a defblock-alias function.


### PR DESCRIPTION
This pull request adds background-color for the details block.

Latex does not support "#<hex>" color specification. So I'm using \definecolor{name}{specification}{hex-code} to define a color in latex first, before using it. This is invoked by checking if the first character of the color string is "#". If not, this is not used and the color is defined by using just \colorlet{name}{color}. I've done this for both title-color and background-color. 
Using the above necessitates the use of ```\usepackage{xcolor}``` in the latex preamble.

It might make sense to define a macro just for the color conversion that needs to be applied for latex. It is also interesting that HTML does not support all kinds of colorlet inputs that latex supports ("red!50!white" works in latex, for instance, but doesn't work in html). There are some elisp packages doing the color conversion, but that looks a little more complicated than perhaps what we need. 