### PR TITLE
Fix undefined variable "label" (small typo)

### DIFF
--- a/org-special-block-extras.el
+++ b/org-special-block-extras.el
@@ -1881,7 +1881,7 @@ We use this listing to actually print a glossary using
                              "[o-glossary-%s]{%s}"
                              "\\label{o-glossary"
                              "-declaration-site-%s}")
-                     label display-name label))))
+                     o-label display-name o-label))))
 
 ;; WHERE ...
 

--- a/org-special-block-extras.org
+++ b/org-special-block-extras.org
@@ -6943,7 +6943,7 @@ time. E.g., upon export =doc:wombo= will produce a no-entry error.
                              "[o-glossary-%s]{%s}"
                              "\\label{o-glossary"
                              "-declaration-site-%s}")
-                     label display-name label))))
+                     o-label display-name o-label))))
 
 ;; WHERE ...
 


### PR DESCRIPTION
The `org-deflink` that defined the `doc` link, on the latex backend, still used the old reference to `label` instead to `o-label` in the `format` call, which make the package unable to load. Changing that small typo fixes the issue.